### PR TITLE
Remove java from asdf

### DIFF
--- a/dot_tool-versions
+++ b/dot_tool-versions
@@ -1,4 +1,3 @@
-java openjdk-18
 nodejs 18.6.0
 yarn 1.22.19
 python 3.10.5

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -238,7 +238,6 @@ if [ -f '/Users/nathanmills/Downloads/google-cloud-sdk/completion.zsh.inc' ]; th
 . $(brew --prefix asdf)/libexec/asdf.sh
 . $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash
 {{- end }}
-. ~/.asdf/plugins/java/set-java-home.zsh
 
 ###########################
 # End asdf setup


### PR DESCRIPTION
asdf installed java caused problems with bazel not being able to find
the java bin. Until I can solve that we are just not going to use asdf
for java
