### PR TITLE
Fix octo.lua timeline_indent type issue

### DIFF
--- a/dot_config/nvim/after/plugin/octo.lua
+++ b/dot_config/nvim/after/plugin/octo.lua
@@ -4,7 +4,7 @@ require"octo".setup({
   reaction_viewer_hint_icon = "";         -- marker for user reactions
   user_icon = " ";                        -- user icon
   timeline_marker = "";                   -- timeline marker
-  timeline_indent = "2";                   -- timeline indentation
+  timeline_indent = 2;                   -- timeline indentation
   right_bubble_delimiter = "";            -- bubble delimiter
   left_bubble_delimiter = "";             -- bubble delimiter
   github_hostname = "";                    -- GitHub Enterprise host


### PR DESCRIPTION
## Summary
- Fix timeline_indent configuration in octo.lua from string "2" to number 2
- Resolves type mismatch issue with the octo plugin configuration

## Test plan
- [x] Verify octo.lua loads without errors
- [x] Check that timeline indentation works correctly in GitHub issue/PR views

🤖 Generated with [Claude Code](https://claude.ai/code)