### PR TITLE
Update mise configuration with additional tools

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -1,4 +1,5 @@
 [tools]
+bun = "latest"
 deno = "latest"
 direnv = "latest"
 go = "latest"
@@ -7,8 +8,12 @@ julia = "latest"
 lua = "latest"
 node = "latest"
 ocaml = "latest"
+opentofu = "latest"
 perl = "latest"
 php = "latest"
 pnpm = "latest"
 python = "system"
 yarn = "latest"
+
+[settings]
+idiomatic_version_file_enable_tools = ["pytho", "python"]


### PR DESCRIPTION
## Summary
- Add `bun` and `opentofu` to mise tools configuration
- Add idiomatic version file settings for Python support
- Sync mise config with current system state

## Changes
- **bun**: Latest JavaScript runtime and package manager
- **opentofu**: Latest open-source Terraform fork
- **Python settings**: Enable idiomatic version file support

## Test plan
- [x] Verify mise installs and manages the new tools correctly
- [x] Check Python version file detection works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)