### PR TITLE
Add delta configuration to gitconfig template

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -9,6 +9,7 @@
 	default = current
 [core]
 	excludesfile = ~/.gitignore_global
+	pager = delta
 [include]
         path = ~/.gitconfigoverride
 [pull]
@@ -33,4 +34,14 @@
 	helper = !/opt/homebrew/bin/gh auth git-credential
   {{ else if eq .chezmoi.os "linux" -}}
   helper = !/usr/bin/gh auth git-credential
-  {{ end -}}
+  {{ end }}
+[credential]
+	helper = store
+[interactive]
+	diffFilter = delta --color-only
+[delta]
+	features = side-by-side line-numbers decorations
+	syntax-theme = Monokai Extended
+	navigate = true
+	line-numbers = true
+	side-by-side = true


### PR DESCRIPTION
## Summary
- Add delta pager configuration to gitconfig template
- Include interactive diff filtering with delta
- Configure delta with side-by-side view, line numbers, and Monokai Extended theme
- Add credential store helper configuration

## Features Added
- **Delta pager**: Enhanced git diff and log output
- **Interactive filtering**: Better `git add -p` experience with delta
- **Visual improvements**: Side-by-side diffs with syntax highlighting
- **Credential management**: Store credential helper for authentication

## Test plan
- [x] Verify delta is installed and available on the system
- [x] Test git diff output uses delta formatting
- [x] Check interactive git add uses delta filtering

🤖 Generated with [Claude Code](https://claude.ai/code)