### PR TITLE
Add Claude Code integration and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tags
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+This is a personal dotfiles repository managed by [chezmoi](https://www.chezmoi.io/). The repository contains configuration files for a comprehensive Linux/macOS development environment including terminal, editor, window manager, and development tools.
+
+## Key Commands
+
+### chezmoi Commands
+- `chezmoi apply` - Apply dotfiles to the system
+- `chezmoi edit <file>` - Edit a template file
+- `chezmoi add <file>` - Add a new file to be managed by chezmoi
+- `chezmoi diff` - Show differences between managed files and target state
+- `chezmoi status` - Show status of files
+
+### System Setup
+- Initial setup: `sh -c "$(curl -fsLS chezmoi.io/get)" -- init --apply rivernate`
+- Package installation (Arch Linux): Run `run_once_install-packages.sh.tmpl` template
+- Package installation (macOS): Run `run_once_brew_bundle.sh.tmpl` template
+
+## Architecture
+
+### Template System
+All configuration files use chezmoi's Go template system:
+- `.tmpl` files are Go templates that generate the actual config files
+- Templates use variables like `{{ .chezmoi.os }}` for cross-platform compatibility
+- Conditional blocks handle different operating systems and configurations
+
+### Key Configuration Areas
+- **Shell**: Zsh with Powerlevel10k theme (`dot_zshrc.tmpl`, `dot_p10k.zsh`)
+- **Editor**: Neovim with Lua configuration (`dot_config/nvim/`)
+- **Terminal**: Multiple terminal emulators (Alacritty, Kitty, WezTerm)
+- **Development**: mise for language version management (`dot_config/mise/config.toml`)
+- **Window Managers**: Support for bspwm, yabai, and Hyprland
+- **Git**: Templated git configuration (`dot_gitconfig.tmpl`)
+
+### Development Tools
+- Languages managed by mise: Node.js, Go, Python, Java, Lua, PHP, Perl, OCaml, Julia, Deno
+- Package managers: yay (Arch), brew (macOS), pnpm, yarn
+- Development utilities: ripgrep, bat, exa, direnv, neovim
+
+### Cross-Platform Support
+The dotfiles support both Linux (primarily Arch Linux) and macOS with conditional templating based on `{{ .chezmoi.os }}` and `{{ .chezmoi.osRelease.id }}`.

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -371,3 +371,8 @@ function dwta() {
     fi
 }
 {{ end -}}
+
+# Claude CLI alias
+if [ -f "/home/nate/.claude/local/claude" ]; then
+    alias claude="/home/nate/.claude/local/claude"
+fi


### PR DESCRIPTION
## Summary
- Add comprehensive CLAUDE.md documentation for future Claude Code instances
- Add .claude/settings.local.json to .gitignore to keep local Claude settings private
- Add guarded claude alias to zshrc template that checks for file existence

## Features Added
- **CLAUDE.md**: Complete repository guide including architecture, commands, and development setup
- **Privacy protection**: Prevent Claude local settings from being committed
- **Smart alias**: Only create claude alias if the binary actually exists

## Benefits
- **Better Claude Code experience**: Future instances can understand the repository structure
- **Cross-platform compatibility**: Guarded alias works on systems with or without Claude CLI
- **Privacy**: Local Claude settings remain local

## Test plan
- [x] Verify CLAUDE.md is ignored by chezmoi but tracked in git
- [x] Test claude alias only activates when binary exists
- [x] Confirm .claude/settings.local.json is properly ignored

🤖 Generated with [Claude Code](https://claude.ai/code)